### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+## Project purpose
+Public scripts and automations for VyOS project infrastructure tasks — primarily Phorge (Phabricator fork) housekeeping and license-report generation. Not part of the VyOS image build; runs as scheduled GitHub Actions against external services.
+
+## Tech stack
+- Python 3 with stdlib + minimal third-party deps. `phabricator_tasks/requirements.txt` declares the runtime libraries.
+- No `pyproject.toml`, no Debian packaging, no `setup.py` — scripts are run directly.
+- GitHub Actions: `phabricator_tasks.yml` (scheduled), `cla-check.yml`.
+
+## Build / test / run
+```
+pip install -r phabricator_tasks/requirements.txt
+python phabricator_tasks/tasks.py
+python phabricator_tasks/get_task_data.py
+python license-report.py
+```
+No test suite.
+
+## Repository layout
+- `phabricator_tasks/`
+  - `tasks.py` — chores: marks tasks resolved when present in "Finished" columns on all boards; unassigns long-stale assigned tasks.
+  - `get_task_data.py` — read-only Phorge data fetcher.
+  - `requirements.txt` — Python deps.
+- `license-report.py` — license-report generator.
+- `LICENSE`, `README.md`.
+- `.github/workflows/phabricator_tasks.yml` — schedule + workflow.
+
+## Cross-repo context
+- Talks to the Phorge instance at https://vyos.dev (Conduit API). Phorge is the canonical task tracker referenced by the `component: T12345: description` commit convention enforced across every other VyOS repo via `vyos/.github`.
+- Adjacent in role to `VyOS-Networks/big-beautiful-order` (Phorge task version-tag auditor) and `VyOS-Networks/cve-checker`. None of these are part of the build pipeline; they are governance tooling.
+- `cla-check.yml` delegates to `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current`.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) where applicable.
+- Default branch: confirm via `git ls-remote --symref`. Treat as a single-track repo (no LTS branches).
+- Public repo: never commit Phorge API tokens, Conduit certificates, or service-account credentials. Inject via GitHub Actions secrets only.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-infrastructure`. The mirror is largely independent (hosts HCL/Ansible IaC for internal infra); this `vyos/*` side is the public housekeeping scripts only. Do not assume code parity.
+
+## Notes for future contributors
+- Phorge API endpoints can change without notice — pin `requirements.txt` and re-test scheduled jobs after any Phorge upgrade.
+- Avoid embedding board PHIDs or task IDs as constants — read them from config or workflow inputs.
+- Adjacent VyOS-side automation (CVE tracking, release process) lives under `VyOS-Networks/cve-checker` and `VyOS-Networks/vyos-release-process`. Coordinate with their maintainers before duplicating logic.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-infrastructure`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544904). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,3 @@ Mirror twin: `VyOS-Networks/vyos-infrastructure`. The mirror is largely independ
 - Phorge API endpoints can change without notice — pin `requirements.txt` and re-test scheduled jobs after any Phorge upgrade.
 - Avoid embedding board PHIDs or task IDs as constants — read them from config or workflow inputs.
 - Adjacent VyOS-side automation (CVE tracking, release process) lives under `VyOS-Networks/cve-checker` and `VyOS-Networks/vyos-release-process`. Coordinate with their maintainers before duplicating logic.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-infrastructure`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544904). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
