### PR TITLE
T8943: migrate mirror wrapper to App-ready uniform stub (rollout 1b Task 5)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -1,3 +1,6 @@
+# .github/workflows/pr-mirror-repo-sync.yml
+# DO NOT EDIT — managed by mirror-pipeline rollout.
+# To opt out: set vars.MIRROR_ENABLED=false in this repo's Actions variables.
 name: PR Mirror and Repo Sync
 
 on:
@@ -7,29 +10,21 @@ on:
   workflow_dispatch:
     inputs:
       sync_branch:
-        description: 'Branch to mirror'
         required: true
-        default: 'main'
-        type: choice
-        options:
-          - main
+        type: string
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
   issues: write
 
 jobs:
-  call-pr-mirror-repo-sync:
+  call:
     if: |
-      github.repository_owner == 'vyos' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-      )
+      github.repository_owner == 'vyos'
+      && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@current
     with:
-      sync_branch: ${{ github.event.inputs.sync_branch || 'main' }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
-      REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}
+      sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Rollout 1b (mirror pipeline PAT→App migration), Task 5. Switches this repo's mirror wrapper from explicit `secrets: PAT/REMOTE_OWNER` pass-through to `secrets: inherit` and adopts the uniform stub (incl. `vars.MIRROR_ENABLED` per-repo kill-switch, default-on). Behavior-neutral against the current PAT-using central workflow. Prepares for the App-token central-workflow update (Task 7).

- Plan: `~/.claude/plans/2026-05-26-mirror-rollout-1b-revised.md` Task 5
- Tracking: T8943

🤖 Generated by [robots](https://vyos.io)
