### PR TITLE
T8943: migrate branch refs main->production (rollout 1c)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [main]
+    branches: [production]
   workflow_dispatch:
     inputs:
       sync_branch:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs main->production in pr-mirror-repo-sync.yml; phabricator_tasks.yml jobs:main: is a job ID not a branch ref (untouched); HIGH-producer pins already swept. Tracking: T8943