### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->production)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ No test suite.
 ## Cross-repo context
 - Talks to the Phorge instance at https://vyos.dev (Conduit API). Phorge is the canonical task tracker referenced by the `component: T12345: description` commit convention enforced across every other VyOS repo via `vyos/.github`.
 - Adjacent in role to an internal repository (Phorge task version-tag auditor) and an internal repository. None of these are part of the build pipeline; they are governance tooling.
-- `cla-check.yml` delegates to `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current`.
+- `cla-check.yml` delegates to `vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@production`.
 
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) where applicable.


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)